### PR TITLE
修复unity2019 4.17f1打包安卓加载proto lib报错问题

### DIFF
--- a/FirClient/Assets/ToLua/Core/LuaDLL.cs
+++ b/FirClient/Assets/ToLua/Core/LuaDLL.cs
@@ -226,6 +226,7 @@ namespace LuaInterface
         [DllImport(LUADLL, CallingConvention = CallingConvention.Cdecl)]
         public static extern int luaopen_sproto_core(IntPtr L);
 
+        [MonoPInvokeCallbackAttribute(typeof(LuaCSFunction))]
         [DllImport(LUADLL, CallingConvention = CallingConvention.Cdecl)]
         public static extern int luaopen_protobuf_c(IntPtr L);
 		/*


### PR DESCRIPTION
修复unity2019 4.17f1打包安卓加载proto lib报错问题